### PR TITLE
パス区切りの指定をPOSIXに対応しました

### DIFF
--- a/src/expandMdcat.ts
+++ b/src/expandMdcat.ts
@@ -82,7 +82,7 @@ class DocIterator
 
 	include(src: string)
 	{
-		let data = readFileSync(this.docDir + "\\" + src)
+		let data = readFileSync(this.docDir + path.sep + src)
 		let ext = extractExtentision(src);
 		let bCSS = (ext === "css");
 
@@ -235,7 +235,7 @@ function getOutputFilePath(mdcatPath: string)
 {
     var s = ""
     s += path.dirname(mdcatPath)
-    s += '\\'
+    s += path.sep
     s += path.basename(mdcatPath, path.extname(mdcatPath))
     s += '.md'
     return s

--- a/src/filePathCompletionProvider.ts
+++ b/src/filePathCompletionProvider.ts
@@ -22,7 +22,7 @@ export default class FilePathCompletionProvider implements vscode.CompletionItem
         
         this.items = new Array<vscode.CompletionItem>();
     
-        let rootPath = path.dirname(editor.document.fileName) + "\\";
+        let rootPath = path.dirname(editor.document.fileName) + path.sep;
 
         // add markdown files
         vscode.workspace.findFiles("**/*.*").then((urls) => {


### PR DESCRIPTION
## 変更目的
MacのVSCodeでMarkdownCatを使うためです。
(MacのVSCodeで[Generate markdown file]を実行した時にファイルが出力されませんでした。)

## 確認手順
1. VSCodeで[Generate maekdown file] を実行する

## 変更内容
出力先のファイルパス の作成に'¥'を使っていたので、POSIX系の環境でうまく動作しませんでした。
パスの作成の際にpath.seqを使う事でPOSIXのパス区切りでも対応できるようにしました。

## その他
- 手元にWindows環境が無いためWindowsのVSCodeの動作に影響が無いか確認できていません
